### PR TITLE
Fix duplicate router export

### DIFF
--- a/backend/routes/postRoutes.js
+++ b/backend/routes/postRoutes.js
@@ -137,9 +137,5 @@ router.post('/add-review', async (req, res) => {
   }
 });
 
-
 module.exports = router;
 
-
-
-module.exports = router;


### PR DESCRIPTION
## Summary
- remove redundant `module.exports` from `postRoutes.js`

## Testing
- `npm test` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68610249819c832f809e1da3ac30ff54